### PR TITLE
LotW ADIF now includes comments. This PR adds code to handle them.

### DIFF
--- a/adifrecord.go
+++ b/adifrecord.go
@@ -55,12 +55,21 @@ func ParseADIFRecord(buf []byte) (*baseADIFRecord, error) {
 	for len(buf) > 0 {
 		var data *fieldData
 		var err error
-		data, buf, err = getNextField(buf)
-		if err != nil {
-			return nil, err
+		if buf[0] == '/' && buf[1] == '/' { // Recognize comments and skip them.
+			end_of_line := bytes.IndexByte(buf, 13)
+			if end_of_line > -1 {
+				buf = buf[end_of_line+1:]
+			} else { // The comment ends the record so there's no end-of-line.
+				buf = buf[len(buf):]
+			}
+		} else {
+			data, buf, err = getNextField(buf)
+			if err != nil {
+				return nil, err
+			}
+			// TODO: accomodate types
+			record.values[data.name] = data.value
 		}
-		// TODO: accomodate types
-		record.values[data.name] = data.value
 	}
 
 	return record, nil

--- a/testdata/lotw.adi
+++ b/testdata/lotw.adi
@@ -11,7 +11,7 @@ Query:
 
 <eoh>
 
-<CALL:5>KD4LV
+<CALL:5>KD4LV  // LotW ADIF now includes comments like this one.
 <BAND:3>20M
 <FREQ:8>14.07639
 <MODE:4>JT65
@@ -19,7 +19,7 @@ Query:
 <QSO_DATE:8>20150226
 <TIME_ON:6>014700
 <QSL_RCVD:1>Y
-<QSLRDATE:8>20150602
+<QSLRDATE:8>20150602 // A comment ending a record is a special case.
 <eor>
 
 <CALL:5>PY2RU


### PR DESCRIPTION
Hi! Was really happy to see that somebody has already done ADIF in Go! Alas, it looks like LotW has added "//" comments to their ADIF since you originally wrote this.

I've added comments to lotw.adi to simulate what LotW is now producing. If you run the tests without the corresponding changes to adifrecord.go, you'll see the failure. Turns out it's only comments that appear _after all fields_ that cause a problem, but my additional code skips them all.