### PR TITLE
Fix parsing header-only ADIF without EOF

### DIFF
--- a/adifreader_test.go
+++ b/adifreader_test.go
@@ -113,11 +113,12 @@ func TestDedupeReadRecord(t *testing.T) {
 
 func TestFullFiles(t *testing.T) {
 	expected := map[string]int{
-		"lotw.adi":       250,
-		"lotw_empty.adi": 0,
-		"lotw_eof.adi":   1,
-		"wsjtx.adi":      74,
-		"xlog.adi":       425,
+		"lotw.adi":              250,
+		"lotw_empty.adi":        0,
+		"lotw_empty_no_eof.adi": 0,
+		"lotw_eof.adi":          1,
+		"wsjtx.adi":             74,
+		"xlog.adi":              425,
 	}
 	for file, count := range expected {
 		fname := filepath.Join("testdata", file)

--- a/testdata/lotw_empty_no_eof.adi
+++ b/testdata/lotw_empty_no_eof.adi
@@ -1,0 +1,14 @@
+ARRL Logbook of the World Status Report
+Generated at 2020-12-02 16:16:18
+for k0swe
+Query:
+    QSL ONLY: NO
+QSO RX SINCE: 2020-12-02 00:00:00 (user supplied value)
+
+<PROGRAMID:4>LoTW
+<APP_LoTW_NUMREC:1>0
+
+<eoh>
+
+
+

--- a/util.go
+++ b/util.go
@@ -16,5 +16,9 @@ func bContainsCI(b, subslice []byte) bool {
 
 // Find start of next tag
 func tagStartPos(b []byte) int {
-	return bytes.IndexByte(b, '<')
+	nextStart := bytes.IndexByte(b, '<')
+	if nextStart == -1 {
+		return 0
+	}
+	return nextStart
 }


### PR DESCRIPTION
This was already fixed in #6 for LotW files with the non-standard EOF headers, but in my app I was still pre-stripping the EOF and was crashing on a -1 array index at https://github.com/Matir/adifparser/blob/e70240124a37612ec1c6cc4968696cc2e6f58812/adifreader.go#L130. This should fix the general case of header-only ADIF files in addition to the special case of LotW EOF files.