### PR TITLE
Add ADIFRecord.DeleteField()

### DIFF
--- a/adifrecord.go
+++ b/adifrecord.go
@@ -183,3 +183,12 @@ func (r *baseADIFRecord) GetFields() []string {
 	}
 	return keys
 }
+
+// Delete a field (from the internal map)
+func (r *baseADIFRecord) DeleteField(name string) (bool, error) {
+	if _, ok := r.values[name]; ok {
+		delete(r.values, name)
+		return true, nil
+	}
+	return false, ErrNoSuchField
+}


### PR DESCRIPTION
Add a DeleteField("fieldname") method to ADIFRecord.
This is necessary to delete an unwanted ADIF data field completely in the map structure of an ADIF record.

I've also added the test code as follows to adifrecord_test.go:

```go
func TestDeleteField(t *testing.T) {
        testData := map[string]string{
                "call":         "W1AW",
                "notes":        "This is a notice",
                "STATION_CALL": "KF4MDV"}
        expected := [2]string{"call", "station_call"}

        record := NewADIFRecord()
        for k, v := range testData {
                record.SetValue(k, v)
        }
        success, err := record.DeleteField("nothere")
        if err != ErrNoSuchField {
                t.Fatal(err)
        }
        success, err = record.DeleteField("notes")
        if !success || err != nil {
                t.Fatalf("success: %t, err: %v", success, err)
        }
        fieldNames := record.GetFields()

        if len(fieldNames) != len(expected) {
                t.Fatalf("Expected %d fields but got %d", len(expected), len(fieldNames))
        }

OUTER:
        for _, exp := range expected {
                for _, field := range fieldNames {
                        if exp == field {
                                continue OUTER
                        }
                }
                t.Fatalf("Expected field %v wasn't in the actual fields", exp)
        }
}
```